### PR TITLE
:bug: changed python default location to leverage %PATH%

### DIFF
--- a/lib/_startup_defaults/a2_settings.ahk
+++ b/lib/_startup_defaults/a2_settings.ahk
@@ -1,7 +1,7 @@
 a2_settings = settings
 a2_modules = modules
 a2_ahk = lib\Autohotkey\Autohotkey.exe
-a2_python = C:\Python34\pythonw.exe
+a2_python = pythonw.exe
 a2_help = https://github.com/ewerybody/a2#description
 SetTitleMatchMode, 2
 a2_tray_click_button = 1


### PR DESCRIPTION
## Description
Change the default python location to use the environment variable _PATH_

## Motivation and Context
solves #71 

## How Has This Been Tested?
* followed the _Steps to Reproduce_ of issue

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.