### PR TITLE
added a2.modules to submodules of the repo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "modules"]
+	path = modules
+	url = https://github.com/ewerybody/a2.modules.git
+	branch = master


### PR DESCRIPTION
### Description
Added the *a2.modules* repo to `.gitmodules`. This way, the a2 repo can be initialized (including the modules) with `git clone ../a2.git --recursive`