### PR TITLE
Hotfix/init call function

### DIFF
--- a/lib/_defaults/a2_init.ahk
+++ b/lib/_defaults/a2_init.ahk
@@ -1,6 +1,8 @@
-﻿#include settings\variables.ahk
-a2_init_calls()
+#include settings\variables.ahk
 #include settings\libs.ahk
 #include settings\includes.ahk
 #include settings\hotkeys.ahk
 #include settings\init.ahk
+
+init_func := "a2_init_calls"
+if IsFunc(init_func) %init_func%()

--- a/lib/_defaults/a2_init.ahk
+++ b/lib/_defaults/a2_init.ahk
@@ -1,8 +1,8 @@
 #include settings\variables.ahk
+initFunc := "a2_init_calls"
+if IsFunc(initFunc)
+    %initFunc%()
 #include settings\libs.ahk
 #include settings\includes.ahk
 #include settings\hotkeys.ahk
 #include settings\init.ahk
-
-init_func := "a2_init_calls"
-if IsFunc(init_func) %init_func%()


### PR DESCRIPTION
### Description
When a2 is started for the first time - and the `settings/ ` to not exist yet, ahk throws an error that a2_init_calls function does not exist

### Motivation and Context
function call must be [Dynamic](https://autohotkey.com/docs/Functions.htm#DynCall)

### How Has This Been Tested?
1. Deleted `settings/`
2. ran a2.exe --> **no error**
3. opened `settings/init.ahk` --> **empty**
4. activated a module
5. opened `settings/init.ahk` --> **empty function**
6. populated `a2_init_calls` function with `msgbox Bingo!`
7. reloaded a2.exe
8. **saw msgbox**

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

