### PR TITLE
get_cfg_value now checks against None and {}

### DIFF
--- a/ui/a2ctrl/__init__.py
+++ b/ui/a2ctrl/__init__.py
@@ -170,7 +170,7 @@ def get_cfg_value(element_cfg, user_cfg, attr_name=None, typ=None, default=None)
     unified call to get a value no matter if its set by user already
     or still default from the module config.
     """
-    if user_cfg is not None and attr_name is None:
+    if user_cfg is not None and user_cfg != {} and attr_name is None:
         value = user_cfg
     elif isinstance(user_cfg, dict) and attr_name in user_cfg:
         value = user_cfg[attr_name]
@@ -193,10 +193,9 @@ def get_cfg_value(element_cfg, user_cfg, attr_name=None, typ=None, default=None)
 
 
 def assemble_settings(module_key, cfg_dict, db_dict, module_path=None):
-
+    a2obj = a2core.A2Obj.inst()
     for cfg in cfg_dict:
         # get configs named db entry of module or None
-        a2obj = a2core.A2Obj.inst()
         cfg_name = a2util.get_cfg_default_name(cfg)
         user_cfg = a2obj.db.get(cfg_name, module_key)
         # pass if there is an 'enabled' entry and it's False


### PR DESCRIPTION
fixed a bug that caused bools to be fetched wrongly

<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

### Screenshots (if appropriate):

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
